### PR TITLE
primary key separation

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -16,6 +16,8 @@ var operatorMap = {
 	"!=": "ne"
 };
 
+exports.primaryKeyName = 'id';
+
 var parseQuery = exports.parse = exports.parseQuery = function(/*String|Object*/query, parameters){
 	if (query === undefined)
 		query = '';
@@ -70,7 +72,7 @@ var parseQuery = exports.parse = exports.parseQuery = function(/*String|Object*/
 			}
 			if(openParan){
 				var newTerm = new Query();
-				newTerm.name = propertyOrValue,
+				newTerm.name = propertyOrValue;
 				newTerm.parent = term;
 				call(newTerm);
 			}
@@ -86,6 +88,10 @@ var parseQuery = exports.parse = exports.parseQuery = function(/*String|Object*/
 			}
 			else if(propertyOrValue || delim === ','){
 				term.args.push(stringToValue(propertyOrValue, parameters));
+				// cache the last seen id equality
+				if (term.name === 'eq' && term.args[0] === exports.primaryKeyName) {
+					topTerm.id = term.args.slice(1).toString();
+				}
 			}
 			return "";
 		});


### PR DESCRIPTION
Now .get() and .query() can be reliably (at least for and-only strings) separated by analysing parsedTerms.id property. GET /Foo/?id=1&select(a,b,c) effectively should mean var x = `GET /Foo/1` and return `RQL.executeQuery('select(a,b,c)', {}, [x])`. That way a convolution between methods exposed by HTTP GET is done.

Please, consider pulling. At least feedback is very welcome.

TIA,
--Vladimir
