### PR TITLE
update js-array to support any and all

### DIFF
--- a/js-array.js
+++ b/js-array.js
@@ -56,7 +56,7 @@ exports.operators = {
 	out: filter(function(value, values){
 		return values.indexOf(value) == -1;
 	}),
-	contains: filter(function(array, value){
+	any: filter(function(array, value){
 		if(typeof value == "function"){
 			return array instanceof Array && array.some(function(v){
 				return value.call([v]).length;
@@ -65,6 +65,17 @@ exports.operators = {
 		else{
 			return array instanceof Array && array.indexOf(value) > -1;
 		}
+	}),
+	all: filter(function(array, value){
+		var filter = typeof value == "function" ?
+			function(v){
+				return value.call([v]).length;
+			} :
+			function(v){
+				return v === value;
+			};
+
+		return array instanceof Array && array.every(filter);
 	}),
 	excludes: filter(function(array, value){
 		if(typeof value == "function"){
@@ -286,6 +297,10 @@ exports.operators = {
 		return this[0];
 	}
 };
+
+// alias any as contains for backwards compat
+exports.operators.contains = exports.operators.any;
+
 exports.filter = filter;
 function filter(condition, not){
 	// convert to boolean right now

--- a/test/js-array.js
+++ b/test/js-array.js
@@ -45,5 +45,13 @@ exports.testFiltering1 = function() {
 	assert.deepEqual(executeQuery("excludes(path.1,7)&sort()", {}, data), [data[0]]); // 7 found in second
 };
 
+exports.testAny = function() {
+	assert.deepEqual(executeQuery(new Query().any("tags", "even"), {}, data), [data[0]], "executeQuery supports the any operator");
+}
+
+exports.testAll = function() {
+	assert.deepEqual(executeQuery(new Query().all("tags", "fun"), {}, data), [data[1]], "executeQuery supports the all operator");
+}
+
 if (require.main === module)
     require("patr/runner").run(exports);


### PR DESCRIPTION
the specification and rql/query have been updated with `any` and `all` rather than `contains` but rql/js-array still only has support for `contains`.  since query does not support `contains`, you can't do

``` js
q = new Query().contains(assigned, user.id);
```

and since js-array doesn't support `any` you can't do

``` js
q = new Query().any('assigned', user.id);
assignedItems = executeQuery(q, {}, data);
```

so, instead you have to use a string query 

``` js
q = new Query('contains(assigned,' + user.id + ')');
assignedItems = executeQuery(q, {}, data);
```
