### PR TITLE
dep issue, colons in property values, fix date re

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "promised-io": ">=0.3.0"
   },
   "devDependencies": {
-    "patr": ">0.2.6"
+    "patr": "~0.2.6"
   },
   "icon": "http://packages.dojofoundation.org/images/persvr.png"
 }

--- a/parser.js
+++ b/parser.js
@@ -176,7 +176,12 @@ function stringToValue(string, parameters){
 		return param_index >= 0 && parameters ? parameters[param_index] : undefined;
 	}
 	if(string.indexOf(":") > -1){
-		var parts = string.split(":",2);
+		var parts = string.split(":");
+
+        // allow colons in value
+        var remaining = parts.splice(1);
+        parts.push(remaining.join(':'));
+
 		converter = exports.converters[parts[0]];
 		if(!converter){
 			throw new URIError("Unknown converter " + parts[0]);
@@ -202,10 +207,10 @@ exports.converters = {
 		}
 		var number = +string;
 		if(isNaN(number) || number.toString() !== string){
-/*			var isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(date);
-			if (isoDate) {
-				return new Date(Date.UTC(+isoDate[1], +isoDate[2] - 1, +isoDate[3], +isoDate[4], +isoDate[5], +isoDate[6]));
-			}*/
+          /*var isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/.exec(x);
+          if (isoDate) {
+            date = new Date(Date.UTC(+isoDate[1], +isoDate[2] - 1, +isoDate[3], +isoDate[4], +isoDate[5], +isoDate[6], +isoDate[7] || 0));
+          }*/
 			string = decodeURIComponent(string);
 			if(exports.jsonQueryCompatible){
 				if(string.charAt(0) == "'" && string.charAt(string.length-1) == "'"){
@@ -238,10 +243,10 @@ exports.converters = {
 		return exports.converters.date(date);
 	},
 	date: function(x){
-		var isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(x);
-		if (isoDate) {
-			date = new Date(Date.UTC(+isoDate[1], +isoDate[2] - 1, +isoDate[3], +isoDate[4], +isoDate[5], +isoDate[6]));
-		}else{
+		var isoDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/.exec(x);
+        if (isoDate) {
+          date = new Date(Date.UTC(+isoDate[1], +isoDate[2] - 1, +isoDate[3], +isoDate[4], +isoDate[5], +isoDate[6], +isoDate[7] || 0));
+        }else{
 			date = new Date(x);
 		}
 		if (isNaN(date.getTime())){

--- a/test/query.js
+++ b/test/query.js
@@ -100,6 +100,9 @@ var queryPairs = {
         //FIXME do we need proper ISO date subset parsing?
         {"a(date)": {name:"and", args:[{name:"a", args:["date"]}]}},
         {"a(date:2009)": {name:"and", args:[{name:"a", args:[(new Date("2009"))]}]}},
+        {"a(date:1989-11-21)": {name: "and", args:[{name: "a", args: [(new Date("1989-11-21"))]}]}},
+        {"a(date:1989-11-21T00:21:00.21Z)": {name: "and", args:[{name: "a", args: [(new Date(Date.UTC(1989, 10, 21, 0, 21, 0, 21)))]}]}},
+        {"a(date:1989-11-21T00:21:00Z)": {name: "and", args:[{name: "a", args: [(new Date(Date.UTC(1989, 10, 21, 0, 21, 0)))]}]}}
         //{"a(date:b)": {name:"and", args:[{name:"a", args:[(new Date(NaN))]}]}} // XXX?// supposed to throw an error
     ],
     "boolean coercion": [


### PR DESCRIPTION
Fixed a dependency issue where there is no npm module patr@>0.2.6.

Values can now have colons in them. Without this functionality, there
is no way to use iso dates.

Fix to iso date string regular expression where milliseconds were not
being picked up.

Added a couple of date parsing tests.
