### PR TITLE
Fix handling of ISO dates

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -180,12 +180,12 @@ function stringToValue(string, parameters){
 		return param_index >= 0 && parameters ? parameters[param_index] : undefined;
 	}
 	if(string.indexOf(":") > -1){
-		var parts = string.split(":",2);
+		var parts = string.split(":");
 		converter = exports.converters[parts[0]];
 		if(!converter){
 			throw new URIError("Unknown converter " + parts[0]);
 		}
-		string = parts[1];
+		string = parts.splice(1).join(':');
 	}
 	return converter(string);
 };

--- a/test/query.js
+++ b/test/query.js
@@ -100,6 +100,7 @@ define(function (require) {
 				//FIXME do we need proper ISO date subset parsing?
 				'a(date)': { name: 'and', args: [{ name: 'a', args: [ 'date' ]}]},
 				'a(date:2009)': { name: 'and', args: [{ name: 'a', args: [ new Date('2009') ]}]},
+				'a(date:2009-01-01T10:00:00Z)': { name: 'and', args: [{ name: 'a', args: [ new Date(Date.UTC(2009, 0, 1, 10)) ]}]},
 				//'a(date:b)': { name: 'and', args: [{ name: 'a', args: [ new Date(NaN) ]}]} // XXX?// supposed to throw an error
 			},
 			'boolean coercion': {


### PR DESCRIPTION
This fixes #30. When passing in a comparison such as ?property=date:2010-01-01T00:00:00Z, an exception was thrown because the date string was being truncated to 2010-01-01T00 prior to being passed to the converter function. This was due to an improper use of the String.split method.

While writing a unit test for this fix, I noticed that the unit test suite was not running correctly, as I could not get my test to fail no matter what I did, despite it clearly failing in my running application. As it turns out, the test runner was running only the very last test from the queryPairs collection, but running it multiple times. I fixed this as well, which had a side-effect of causing two existing tests to fail (now that these tests were in fact actually executing, they turned out to be failing). I fixed those as best as I could, but the first one in particular I fixed only by a workaround of adding parentheses to the entire expression.
