### PR TITLE
Fixed Webpack/AMD support

### DIFF
--- a/js-array.js
+++ b/js-array.js
@@ -3,8 +3,7 @@
  * require("./js-array").query("a=3", {}, [{a:1},{a:3}]) -> [{a:3}]
  *
  */
-
-({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./parser"), require("./query"), require("./util/each"), require("./util/contains"));}}).
+if (typeof define !== 'function') { var define = require('amdefine')(module) }
 define(["exports", "./parser", "./query", "./util/each", "./util/contains"], function(exports, parser, QUERY, each, contains){
 //({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./parser"));}}).
 //define(["exports", "./parser"], function(exports, parser){

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "promised-io": "http://github.com/kriszyp/promised-io/zipball/v0.2.1"
   },
   "dependencies": {
+    "amdefine": "^1.0.0",
     "promised-io": ">=0.3.0"
   },
   "devDependencies": {

--- a/parser.js
+++ b/parser.js
@@ -2,7 +2,7 @@
  * This module provides RQL parsing. For example:
  * var parsed = require("./parser").parse("b=3&le(c,5)");
  */
-({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./util/contains"));}}).
+if (typeof define !== 'function') { var define = require('amdefine')(module) }
 define(["exports", "./util/contains"], function(exports, contains){
 
 var operatorMap = {

--- a/query.js
+++ b/query.js
@@ -9,9 +9,7 @@
  *	 // for each object that matches the query
  * });
  */
-//({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./parser"), require("./js-array"));}}).
-//define(["exports", "./parser", "./js-array"], function(exports, parser, jsarray){
-({define:typeof define!="undefined"?define:function(deps, factory){module.exports = factory(exports, require("./parser"), require("./util/each"));}}).
+if (typeof define !== 'function') { var define = require('amdefine')(module) }
 define(["exports", "./parser", "./util/each"], function(exports, parser, each){
 
 var parseQuery = parser.parseQuery;

--- a/query.js
+++ b/query.js
@@ -79,28 +79,32 @@ function encodeString(s) {
 exports.encodeValue = function(val) {
 		var encoded;
 		if (val === null) val = 'null';
-		if (val !== parser.converters["default"]('' + (
-				val.toISOString && val.toISOString() || val.toString()
-		))) {
-				var type = typeof val;
-				if(val instanceof RegExp){
-					// TODO: control whether to we want simpler glob() style
-					val = val.toString();
-					var i = val.lastIndexOf('/');
-					type = val.substring(i).indexOf('i') >= 0 ? "re" : "RE";
-					val = encodeString(val.substring(1, i));
-					encoded = true;
-				}
-				if(type === "object"){
-						type = "epoch";
-						val = val.getTime();
+		try {
+			if (val !== parser.converters["default"]('' + (
+					val.toISOString && val.toISOString() || val.toString()
+			))) {
+					var type = typeof val;
+					if(val instanceof RegExp){
+						// TODO: control whether to we want simpler glob() style
+						val = val.toString();
+						var i = val.lastIndexOf('/');
+						type = val.substring(i).indexOf('i') >= 0 ? "re" : "RE";
+						val = encodeString(val.substring(1, i));
 						encoded = true;
-				}
-				if(type === "string") {
-						val = encodeString(val);
-						encoded = true;
-				}
-				val = [type, val].join(":");
+					}
+					if(type === "object"){
+							type = "epoch";
+							val = val.getTime();
+							encoded = true;
+					}
+					if(type === "string") {
+							val = encodeString(val);
+							encoded = true;
+					}
+					val = [type, val].join(":");
+			}
+		} catch (conversionError) {
+			// The conversion necessity check has failed and we have not encoded the value. The next conditional block will take care of it.
 		}
 		if (!encoded && typeof val === "string") val = encodeString(val);
 		return val;

--- a/query.js
+++ b/query.js
@@ -76,37 +76,56 @@ function encodeString(s) {
 		return s;
 }
 
+/**
+ * Encode a value of a part's argument for use in an RQL string.
+ * @param {*} val - The value to encode.
+ * @returns {string} The encoded value, URI-safe.
+ */
 exports.encodeValue = function(val) {
-		var encoded;
-		if (val === null) val = 'null';
+		// Remember whether any encoding took place. The function force-encodes
+		//  the value as a plain string at the end as a last resort.
+		var encoded = false;
+
+		// Try encoding the value. If it throws, go to our failsafe.
 		try {
-			if (val !== parser.converters["default"]('' + (
-					val.toISOString && val.toISOString() || val.toString()
-			))) {
-					var type = typeof val;
-					if(val instanceof RegExp){
-						// TODO: control whether to we want simpler glob() style
-						val = val.toString();
-						var i = val.lastIndexOf('/');
-						type = val.substring(i).indexOf('i') >= 0 ? "re" : "RE";
-						val = encodeString(val.substring(1, i));
-						encoded = true;
-					}
-					if(type === "object"){
-							type = "epoch";
-							val = val.getTime();
-							encoded = true;
-					}
-					if(type === "string") {
-							val = encodeString(val);
-							encoded = true;
-					}
-					val = [type, val].join(":");
+			// Check whether casting the value to a string and parsing it would
+			//  result in the input value (i.e. if the value can be left prefix-less).
+			var stringVal = '' + ((val && val.toISOString) ? val.toISOString() : val);
+			var parsedStringVal = parser.converters["default"](stringVal);
+			if (val === parsedStringVal) {
+				return encodeString(String(val));
 			}
+			// Now, only non-trivial cases are left:
+			var type = typeof val;
+			if (val instanceof RegExp) {
+				// TODO: control whether to we want simpler glob() style
+				val = val.toString();
+				var i = val.lastIndexOf('/');
+				type = val.substring(i).indexOf('i') >= 0 ? "re" : "RE";
+				val = encodeString(val.substring(1, i));
+				encoded = true;
+			}
+			if (type === "object") {
+				// Assume it's a date - it's the only other object type we support:
+				type = "epoch";
+				val = val.getTime();
+				encoded = true;
+			}
+			if (type === "string") {
+				// It's a string, but it doesn't parse to its own exact value.
+				// This happens when the input is a String('null') for example -
+				//  the auto-converter parses null to type null, so we need a prefix.
+				val = encodeString(val);
+				encoded = true;
+			}
+			val = [type, val].join(":");
 		} catch (conversionError) {
 			// The conversion necessity check has failed and we have not encoded the value. The next conditional block will take care of it.
 		}
-		if (!encoded && typeof val === "string") val = encodeString(val);
+		if (!encoded && typeof val === "string") {
+			val = encodeString(val);
+		}
+		val = String(val);
 		return val;
 };
 

--- a/util/contains.js
+++ b/util/contains.js
@@ -1,4 +1,4 @@
-({define:typeof define!=='undefined'?define:function(deps, factory){module.exports = factory(exports);}}).
+if (typeof define !== 'function') { var define = require('amdefine')(module) }
 define([], function(){
 return contains;
 

--- a/util/each.js
+++ b/util/each.js
@@ -1,4 +1,4 @@
-({define:typeof define!=='undefined'?define:function(deps, factory){module.exports = factory(exports);}}).
+if (typeof define !== 'function') { var define = require('amdefine')(module) }
 define([], function(){
 return each;
 


### PR DESCRIPTION
This change makes it possible to use rql with webpack. It adds a dependency on amdefine to package.json to avoid implementing the shims manually in every file. Tested under Node 6.0 and Webpack 1.13.0.
Fixes #69 .
